### PR TITLE
Add simple calendar script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# 22
+# Calendar Script
+
+This repository contains a simple Python script to display a monthly calendar.
+
+## Usage
+
+```bash
+python3 calendar_script.py [YEAR] [MONTH]
+```
+
+- `YEAR` defaults to the current year if omitted.
+- `MONTH` defaults to the current month if omitted and must be between 1 and 12.
+
+Example:
+
+```bash
+python3 calendar_script.py 2024 6
+```
+
+This will display the calendar for June 2024.

--- a/calendar_script.py
+++ b/calendar_script.py
@@ -1,0 +1,19 @@
+import argparse
+import calendar
+from datetime import datetime
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Print a monthly calendar")
+    parser.add_argument("year", nargs="?", type=int, help="Year of the calendar", default=datetime.now().year)
+    parser.add_argument("month", nargs="?", type=int, help="Month of the calendar (1-12)", default=datetime.now().month)
+    args = parser.parse_args()
+
+    if not 1 <= args.month <= 12:
+        parser.error("month must be in 1..12")
+    cal = calendar.TextCalendar()
+    print(cal.formatmonth(args.year, args.month))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a Python script that prints a monthly calendar
- document usage in README

## Testing
- `python3 calendar_script.py 2024 6 | head`


------
https://chatgpt.com/codex/tasks/task_e_684381191530832787dfcb7a3f063eab