### PR TITLE
Add 3D Earth demo with Three.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# 22
+# 3D Earth Demo
+
+Open `index.html` in a web browser to view a simple 3D model of Earth rendered with [Three.js](https://threejs.org/).

--- a/index.html
+++ b/index.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>3D Earth</title>
+  <style>
+    body { margin: 0; }
+    canvas { display: block; }
+  </style>
+</head>
+<body>
+<script src="https://cdn.jsdelivr.net/npm/three@0.158.0/build/three.min.js"></script>
+<script>
+// Set up scene, camera, and renderer
+const scene = new THREE.Scene();
+const camera = new THREE.PerspectiveCamera(
+  75,
+  window.innerWidth / window.innerHeight,
+  0.1,
+  1000
+);
+const renderer = new THREE.WebGLRenderer({ antialias: true });
+renderer.setSize(window.innerWidth, window.innerHeight);
+document.body.appendChild(renderer.domElement);
+
+// Lighting
+const light = new THREE.DirectionalLight(0xffffff, 1);
+light.position.set(5, 3, 5);
+scene.add(light);
+
+// Load Earth texture
+const textureLoader = new THREE.TextureLoader();
+const earthTexture = textureLoader.load(
+  'https://threejsfundamentals.org/threejs/resources/images/earth-day.jpg'
+);
+
+// Create sphere and apply texture
+const geometry = new THREE.SphereGeometry(2, 64, 64);
+const material = new THREE.MeshPhongMaterial({ map: earthTexture });
+const earth = new THREE.Mesh(geometry, material);
+scene.add(earth);
+
+camera.position.z = 5;
+
+// Animation loop
+function animate() {
+  requestAnimationFrame(animate);
+  earth.rotation.y += 0.001;
+  renderer.render(scene, camera);
+}
+animate();
+
+// Handle window resize
+window.addEventListener('resize', () => {
+  camera.aspect = window.innerWidth / window.innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(window.innerWidth, window.innerHeight);
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add an index.html demonstrating a textured 3D Earth using Three.js
- update README with instructions to open the demo

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a78ba805508327a371bec96b62a159